### PR TITLE
fix：fixed crash issues when the illegal topic is received

### DIFF
--- a/mqtt/MQTTDeserializePublish.c
+++ b/mqtt/MQTTDeserializePublish.c
@@ -50,7 +50,7 @@ int MQTTDeserialize_publish(unsigned char* dup, int* qos, unsigned char* retaine
 	*qos = header.bits.qos;
 	*retained = header.bits.retain;
 
-	curdata += (rc = MQTTPacket_decodeBuf(curdata, &mylen)); /* read remaining length */
+	curdata += MQTTPacket_decodeBuf(curdata, &mylen); /* read remaining length */
 	enddata = curdata + mylen;
 
 	if (!readMQTTLenString(topicName, &curdata, enddata) ||


### PR DESCRIPTION
在大量压测中，设备建立mqtt连接之后，偶现收到下行异常主题（出现异常主题原因我怀疑时，socket读取到异常消息所致），概率出现crash问题。
原因：
line56中，if条件语句为真，即异常exit，返回值理应为error（0）。但实际返回值却可能会被line53行修改为了1。
此时调用MQTTDeserialize_publish接口的逻辑，可能会因为payload为空，及payloadlen为0，产生非法地址访问。